### PR TITLE
Remove the current theme's stylesheet when viewing a presentation

### DIFF
--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'Reveal_Presentations' ) ) {
 			add_action( 'init', array( $this, 'register_post_types' ) );
 			add_action( 'admin_init', array( $this, 'admin_init' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ), 99 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 			add_filter( 'template_include', array( $this, 'template_include' ), 99 );
 			add_action( 'template_redirect', array( $this, 'template_redirect' ), 1 );
@@ -1096,7 +1096,23 @@ if ( RJSSignageConfig.poll ) {
 		function enqueue_styles() {
 			if ( ! is_tax( 'presentation' ) )
 				return;
-			
+
+			// Find theme's stylesheet
+			$styles = wp_styles();
+
+			$theme_handle = '';
+			foreach ( $styles->registered as $queue => $arg ) {
+				if ( false !== strpos( $arg->src, get_stylesheet_uri() ) ) {
+					$theme_handle = $arg->handle;
+					break;
+				}
+			}
+
+			// Found the theme's stylesheet; let's remove it!
+			if ( ! empty( $theme_handle ) ) {
+				wp_deregister_style( $theme_handle );
+			}
+
 			$options = $this->get_presentation_settings();
 			if ( 'default' == $options['theme'] )
 				$options['theme'] = 'league';

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1101,16 +1101,33 @@ if ( RJSSignageConfig.poll ) {
 			$styles = wp_styles();
 
 			$theme_handle = '';
+			$parent_theme_handle = '';
 			foreach ( $styles->registered as $queue => $arg ) {
+				// Main theme
 				if ( false !== strpos( $arg->src, get_stylesheet_uri() ) ) {
 					$theme_handle = $arg->handle;
-					break;
+
+					if ( ! is_child_theme() ) {
+						break;
+					}
+				}
+
+				// Parent theme
+				if ( is_child_theme() && false !== ( strpos( $arg->src, get_template_directory_uri() . '/style.css' ) ) ) {
+					$parent_theme_handle = $arg->handle;
+
+					if ( ! empty( $theme_handle ) ) {
+						break;
+					}
 				}
 			}
 
 			// Found the theme's stylesheet; let's remove it!
 			if ( ! empty( $theme_handle ) ) {
 				wp_deregister_style( $theme_handle );
+			}
+			if ( ! empty( $parent_theme_handle ) ) {
+				wp_deregister_style( $parent_theme_handle );
 			}
 
 			$options = $this->get_presentation_settings();


### PR DESCRIPTION
Hi Curtiss,

The current theme's stylesheet can conflict with the plugin due to persistent `<body>` styles.

For example, try enabling the twentyfifteen theme and view a presentation.  The presentation's background does not take effect due to twentyfifteen's styles.

This PR removes the current theme's stylesheet (and the parent theme's stylesheet if applicable) when viewing a presentation to avoid this problem.
