### PR TITLE
Fix for piggybacking off of Jetpack's Custom CSS module

### DIFF
--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1491,9 +1491,14 @@ if ( RJSSignageConfig.poll ) {
 			if ( empty( $css ) )
 				return null;
 				
-			if ( ! class_exists( 'Jetpack_Custom_CSS' ) ) {
+			if ( ! defined( 'JETPACK__VERSION' ) ) {
 				return $this->inst_css_parser( $css );
 			} else {
+				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) && function_exists( 'jetpack_load_custom_css' ) ) {
+					jetpack_load_custom_css();
+				} else {
+					require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
+				}
 				return Jetpack_Custom_CSS::minify( $css, 'sass' );
 			}
 		}

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1504,7 +1504,13 @@ if ( RJSSignageConfig.poll ) {
 						require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
 					}
 				}
-				return Jetpack_Custom_CSS::minify( $css, 'sass' );
+
+				$css = @Jetpack_Custom_CSS::minify( $css, 'sass' );
+				if ( empty( $css ) ) {
+					return null;
+				}
+
+				return $css;
 			}
 		}
 		

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -32,7 +32,7 @@ if ( ! class_exists( 'Reveal_Presentations' ) ) {
 			'poll'         => false, 
 			'pollInterval' => 0, 
 		);
-		var $themes = array( 'default', 'beige', 'sky', 'night', 'serif', 'simple', 'solarized', 'none' );
+		var $themes = array( 'default', 'beige', 'sky', 'night', 'serif', 'simple', 'solarized', 'black', 'blood', 'league', 'moon', 'white', 'none' );
 		var $transitions = array( 'default', 'cube', 'page', 'concave', 'zoom', 'linear', 'fade', 'none' );
 		var $customcss = '';
 		

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1494,10 +1494,12 @@ if ( RJSSignageConfig.poll ) {
 			if ( ! defined( 'JETPACK__VERSION' ) ) {
 				return $this->inst_css_parser( $css );
 			} else {
-				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) && function_exists( 'jetpack_load_custom_css' ) ) {
-					jetpack_load_custom_css();
-				} else {
-					require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
+				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) ) {
+					if ( function_exists( 'jetpack_load_custom_css' ) ) {
+						jetpack_load_custom_css();
+					} else {
+						require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
+					}
 				}
 				return Jetpack_Custom_CSS::minify( $css, 'sass' );
 			}

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -975,7 +975,7 @@ if ( ! class_exists( 'Reveal_Presentations' ) ) {
 		 */
 		function _slide_defaults() {
 			return apply_filters( 'reveal-js-slide-defaults', array( 
-				'use-title' => true, 
+				'use-title' => false, 
 				'use-image' => false, 
 				'background' => null, 
 				'transition' => null, 

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'Reveal_Presentations' ) ) {
 			add_action( 'init', array( $this, 'register_post_types' ) );
 			add_action( 'admin_init', array( $this, 'admin_init' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ), 99 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 			add_filter( 'template_include', array( $this, 'template_include' ), 99 );
 			add_action( 'template_redirect', array( $this, 'template_redirect' ), 1 );

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -975,7 +975,7 @@ if ( ! class_exists( 'Reveal_Presentations' ) ) {
 		 */
 		function _slide_defaults() {
 			return apply_filters( 'reveal-js-slide-defaults', array( 
-				'use-title' => false, 
+				'use-title' => true, 
 				'use-image' => false, 
 				'background' => null, 
 				'transition' => null, 

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1497,7 +1497,10 @@ if ( RJSSignageConfig.poll ) {
 				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) ) {
 					if ( function_exists( 'jetpack_load_custom_css' ) ) {
 						jetpack_load_custom_css();
-					} else {
+					}
+
+					// Still here? Load module manually.
+					if ( ! class_exists( 'Jetpack_Custom_CSS', false ) ) {
 						require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
 					}
 				}


### PR DESCRIPTION
Hi @cgrymala,

Jetpack 4.4.2 changed how the Custom CSS module is loaded.  This broke how your plugin looks for JP's Custom CSS module.

This PR should fix this up.

One thing this PR doesn't fix is how your plugin attempts to load a SCSS processor if Jetpack isn't available.  Read the first two comments on our repo for more details - https://github.com/hwdsbcommons/reveal-js-presentations/issues/6.

----

Also, commit 09c07e7 addresses issues with the current theme's CSS sometimes taking precedence over the selected reveal.js theme.  See https://github.com/hwdsbcommons/reveal-js-presentations/issues/6#issuecomment-265357794 for more details.