### PR TITLE
Fix for piggybacking off of Jetpack's Custom CSS module

### DIFF
--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1530,7 +1530,10 @@ if ( RJSSignageConfig.poll ) {
 				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) ) {
 					if ( function_exists( 'jetpack_load_custom_css' ) ) {
 						jetpack_load_custom_css();
-					} else {
+					}
+
+					// Still here? Load module manually.
+					if ( ! class_exists( 'Jetpack_Custom_CSS', false ) ) {
 						require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
 					}
 				}

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1527,10 +1527,12 @@ if ( RJSSignageConfig.poll ) {
 			if ( ! defined( 'JETPACK__VERSION' ) ) {
 				return $this->inst_css_parser( $css );
 			} else {
-				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) && function_exists( 'jetpack_load_custom_css' ) ) {
-					jetpack_load_custom_css();
-				} else {
-					require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
+				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) ) {
+					if ( function_exists( 'jetpack_load_custom_css' ) ) {
+						jetpack_load_custom_css();
+					} else {
+						require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
+					}
 				}
 				return Jetpack_Custom_CSS::minify( $css, 'sass' );
 			}

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1537,7 +1537,13 @@ if ( RJSSignageConfig.poll ) {
 						require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
 					}
 				}
-				return Jetpack_Custom_CSS::minify( $css, 'sass' );
+
+				$css = @Jetpack_Custom_CSS::minify( $css, 'sass' );
+				if ( empty( $css ) ) {
+					return null;
+				}
+
+				return $css;
 			}
 		}
 		

--- a/classes/class-reveal-presentations.php
+++ b/classes/class-reveal-presentations.php
@@ -1524,9 +1524,14 @@ if ( RJSSignageConfig.poll ) {
 			if ( empty( $css ) )
 				return null;
 				
-			if ( ! class_exists( 'Jetpack_Custom_CSS' ) ) {
+			if ( ! defined( 'JETPACK__VERSION' ) ) {
 				return $this->inst_css_parser( $css );
 			} else {
+				if ( ! class_exists( 'Jetpack_Custom_CSS', false ) && function_exists( 'jetpack_load_custom_css' ) ) {
+					jetpack_load_custom_css();
+				} else {
+					require JETPACK__PLUGIN_DIR . 'modules/custom-css/custom-css.php';
+				}
 				return Jetpack_Custom_CSS::minify( $css, 'sass' );
 			}
 		}


### PR DESCRIPTION
Hi @cgrymala,

Jetpack 4.4.2 changed how the Custom CSS module is loaded.  This broke how your plugin looks for JP's Custom CSS module.

This PR should fix this up.

One thing this PR doesn't fix is how your plugin attempts to load a SCSS processor if Jetpack isn't available.  See #7 and also read the first two comments on our repo for more details - https://github.com/hwdsbcommons/reveal-js-presentations/issues/6.